### PR TITLE
Fix grammar deviation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Mais vídeos do Felipão? [Veja meu Canal do Youtube.](https://www.youtube.com/@
       </td>
 			<td valign="top">
 			<h3>Angular Blog</h3>
-			<p>An Simple blog with Angular, good pratices for folder structure.</p>
+			<p>A Simple blog with Angular, good pratices for folder structure.</p>
 			</td>
 		</tr>
 	</tbody>


### PR DESCRIPTION
fix: excluded the "n" from "An Simple Blog with Angular" as "an" is used as an article before words that start with vowels, not consonants.